### PR TITLE
Minor changes to code styling

### DIFF
--- a/themes/hugo-material-docs/static/stylesheets/application.css
+++ b/themes/hugo-material-docs/static/stylesheets/application.css
@@ -820,7 +820,7 @@ pre span {
 }
 
 .article code {
-    background: #eee
+    background: #f5f2f0
 }
 
 .article kbd {

--- a/themes/hugo-material-docs/static/stylesheets/prism/prism.css
+++ b/themes/hugo-material-docs/static/stylesheets/prism/prism.css
@@ -26,6 +26,7 @@ pre[class*="language-"] {
 	-moz-hyphens: none;
 	-ms-hyphens: none;
 	hyphens: none;
+	font-size: 12.5px;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
@@ -106,7 +107,7 @@ pre[class*="language-"] {
 .language-css .token.string,
 .style .token.string {
 	color: #a67f59;
-	background: hsla(0, 0%, 100%, .5);
+/*background: hsla(0, 0%, 100%, .5);*/
 }
 
 .token.atrule,


### PR DESCRIPTION
Code now has the same background as its rectangle and the font is smaller, more in line with the rest of the text.

Before: [https://imgur.com/a/6Faxr](https://imgur.com/a/6Faxr)

After: [https://imgur.com/a/LVXzd](https://imgur.com/a/LVXzd)